### PR TITLE
Disable removeClippedSubviews

### DIFF
--- a/SegmentedControlTab.js
+++ b/SegmentedControlTab.js
@@ -55,7 +55,7 @@ const SegmentedControlTab = ({
     return (
         <View
             style={[styles.tabsContainerStyle, tabsContainerStyle]}
-            removeClippedSubviews={true}>
+            removeClippedSubviews={false}>
             {
                 values.map((item, index) => {
                     return (


### PR DESCRIPTION
Fixes blank initial view reported in issue #15 - tested on iOS