### PR TITLE
If there are only two tabs, add a right border width of 1 to the first tab

### DIFF
--- a/SegmentedControlTab.js
+++ b/SegmentedControlTab.js
@@ -73,7 +73,7 @@ const SegmentedControlTab = ({
     onTabPress,
 }) => {
 
-    const firstTabStyle = [{ borderRightWidth: 0, borderTopLeftRadius: borderRadius, borderBottomLeftRadius: borderRadius }]
+    const firstTabStyle = [{ borderRightWidth: values.length == 2 ? 1 : 0, borderTopLeftRadius: borderRadius, borderBottomLeftRadius: borderRadius }]
     const lastTabStyle = [{ borderLeftWidth: 0, borderTopRightRadius: borderRadius, borderBottomRightRadius: borderRadius }]
 
     return (


### PR DESCRIPTION
When there are only two tabs, there is no middle line between the two tabs. The fix is a ternary operator added to the firstTabStyle constant. 

Here is an example of the bug that this fix addresses:

<img width="495" alt="screen shot 2017-12-21 at 3 06 35 pm" src="https://user-images.githubusercontent.com/19275770/34277662-fc4ee47e-e663-11e7-8c5c-54dc99ecea91.png">

