### PR TITLE
fix border style when there is only single Tab

### DIFF
--- a/SegmentedControlTab.js
+++ b/SegmentedControlTab.js
@@ -77,8 +77,8 @@ const SegmentedControlTab = ({
     allowFontScaling,
 }) => {
 
-    const firstTabStyle = [{ borderRightWidth: values.length == 2 ? 1 : 0, borderTopLeftRadius: borderRadius, borderBottomLeftRadius: borderRadius }]
-    const lastTabStyle = [{ borderLeftWidth: 0, borderTopRightRadius: borderRadius, borderBottomRightRadius: borderRadius }]
+    const firstTabStyle = [{ borderRightWidth: values.length < 3 ? 1 : 0, borderTopLeftRadius: borderRadius, borderBottomLeftRadius: borderRadius }]
+    const lastTabStyle = [{ borderLeftWidth: values.length == 1 ? 1 : 0, borderTopRightRadius: borderRadius, borderBottomRightRadius: borderRadius }]
 
     return (
         <View
@@ -95,8 +95,8 @@ const SegmentedControlTab = ({
                             text={item}
                             textNumberOfLines={textNumberOfLines}
                             onTabPress={(index) => handleTabPress(index, multiple, selectedIndex, onTabPress)}
-                            firstTabStyle={index === 0 ? [{ borderRightWidth: 0 }, firstTabStyle] : {}}
-                            lastTabStyle={index === values.length - 1 ? [{ borderLeftWidth: 0 }, lastTabStyle] : {}}
+                            firstTabStyle={index === 0 ? [firstTabStyle] : {}}
+                            lastTabStyle={index === values.length - 1 ? [lastTabStyle] : {}}
                             tabStyle={[tabStyle, index !== 0 && index !== values.length - 1 ? { marginLeft: -1 } : {}]}
                             activeTabStyle={activeTabStyle}
                             tabTextStyle={tabTextStyle}


### PR DESCRIPTION
When there is only 1 Tab. then the borderline style is broken.

If you remove all color and only use borderline color, then you will see there is no `borderColor` in right and left side like this
![image](https://user-images.githubusercontent.com/14098612/40470741-60e0b3ca-5f6f-11e8-8bc0-78d06ebd5d40.png)


After fix in this PR
![image](https://user-images.githubusercontent.com/14098612/40470764-7005b94a-5f6f-11e8-9bf3-15cd31298972.png)
