### PR TITLE
Allow components and strings on tabs 

### DIFF
--- a/src/SegmentedControlTab.js
+++ b/src/SegmentedControlTab.js
@@ -174,7 +174,8 @@ export default class SegmentedControlTab extends PureComponent<Props> {
                   ? selectedIndices.includes(index)
                   : selectedIndex === index
               }
-              text={item}
+              text={typeof item === 'string' ? item : null}
+              component={React.isValidElement(item) ? item : null}
               textNumberOfLines={textNumberOfLines}
               onTabPress={indexs => handleTabPress(indexs, multiple, selectedIndex, onTabPress)
               }
@@ -202,7 +203,7 @@ export default class SegmentedControlTab extends PureComponent<Props> {
               allowFontScaling={allowFontScaling}
               activeTabOpacity={activeTabOpacity}
               accessible={accessible}
-              accessibilityLabel={accessibilityText || item}
+              accessibilityLabel={accessibilityText || typeof item === 'string' ? item : null}
               enabled={enabled}
             />
           )

--- a/src/SegmentedControlTab.js
+++ b/src/SegmentedControlTab.js
@@ -174,8 +174,8 @@ export default class SegmentedControlTab extends PureComponent<Props> {
                   ? selectedIndices.includes(index)
                   : selectedIndex === index
               }
-              text={typeof item === 'string' ? item : null}
-              component={React.isValidElement(item) ? item : null}
+              text={item}
+              component={item}
               textNumberOfLines={textNumberOfLines}
               onTabPress={indexs => handleTabPress(indexs, multiple, selectedIndex, onTabPress)
               }

--- a/src/TabOption.js
+++ b/src/TabOption.js
@@ -19,6 +19,7 @@ type Props = {
   index?: number,
   badge?: any,
   text: string,
+  component: Element,
   firstTabStyle?: ViewStyleProp,
   lastTabStyle?: ViewStyleProp,
   tabStyle?: ViewStyleProp,
@@ -108,6 +109,7 @@ export default class TabOption extends PureComponent<Props> {
       index,
       badge,
       text,
+      component,
       firstTabStyle,
       lastTabStyle,
       tabStyle,
@@ -144,20 +146,23 @@ export default class TabOption extends PureComponent<Props> {
         activeOpacity={activeTabOpacity}
       >
         <View style={{ flexDirection: 'row' }}>
-          <Text
-            style={[
-              styles.tabTextStyle,
-              tabTextStyle,
-              isTabActive
-                ? [styles.activeTabTextStyle, activeTabTextStyle]
-                : {},
-            ]}
-            numberOfLines={textNumberOfLines}
-            allowFontScaling={allowFontScaling}
-            ellipsizeMode="tail"
-          >
-            {text}
-          </Text>
+          {typeof text === 'string' ? (
+              <Text
+                  style={[
+                    styles.tabTextStyle,
+                    tabTextStyle,
+                    isTabActive
+                        ? [styles.activeTabTextStyle, activeTabTextStyle]
+                        : {},
+                  ]}
+                  numberOfLines={textNumberOfLines}
+                  allowFontScaling={allowFontScaling}
+                  ellipsizeMode="tail"
+              >
+                {text}
+              </Text>
+          ) : component }
+
           {Boolean(badge) && (
             <View
               style={[

--- a/src/TabOption.js
+++ b/src/TabOption.js
@@ -161,8 +161,8 @@ export default class TabOption extends PureComponent<Props> {
               >
                 {text}
               </Text>
-          ) : component }
-
+          ) : null }
+          {React.isValidElement(component) ? component : null}
           {Boolean(badge) && (
             <View
               style={[


### PR DESCRIPTION
This allow to use a string or a react element on tabs, intead of values={['A','B','C']} you can use [<Text>A</Text>,<Text>B</Text>,<Text>C</Text>]
