### PR TITLE
Support maxFontSizeMultiplier

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ class ConsumerComponent extends Component {
 | activeTabBadgeStyle          | external style can be passed to override the default style of the active badge text                                                         | base styles added in SegmentedControlTab.js | object(styles)            |
 | onTabPress                   | call-back function when a tab is selected                                                                                                   | () => {}                                    | func                      |
 | allowFontScaling             | whether the segment & badge text should allow font scaling (default matches React Native default)                                           | true                                        | bool                      |
+| maxFontSizeMultiplier        | the maximum font scale for the segment & badge text, only applicable if font scaling is enabled (default matches React Native default)      | null                                        | number                    |
 | accessible                   | enables accessibility for each tab                                                                                                          | true                                        | bool                      |
 | accessibilityLabels          | Reads out the given text on each tab press when voice over is enabled. If not set, uses the text passed in as values in props as a fallback | ['Label 1', 'Label 2', 'Label 3']           | array                     |
 | activeTabOpacity             | Opacity value to customize tab press                                                                                                        | 1                                           | number                    |
@@ -106,6 +107,7 @@ class ConsumerComponent extends Component {
   activeTabTextStyle={styles.activeTabTextStyle}
   selectedIndex={1}
   allowFontScaling={false}
+  maxFontSizeMultiplier={1.1}
   values={["First", "Second", "Third"]}
   onTabPress={index => this.setState({ selected: index })}
 />;

--- a/index.d.ts
+++ b/index.d.ts
@@ -43,6 +43,8 @@ export interface SegmentedControlTabProperties extends React.Props<ReactNativeSe
     onTabPress?: (index: number) => void
     // Default  true;whether the segment & badge text should allow font scaling (default matches React Native default)
     allowFontScaling?: boolean
+    // Default  null;the maximum font scale for the segment & badge text, only applicable if font scaling is enabled (default matches React Native default)
+    maxFontSizeMultiplier?: number | null
     // Default  true;enables accessibility for each tab
     accessible?: boolean
     // Default  ['Label 1', 'Label 2', 'Label 3'];Reads out the given text on each tab press when voice over is enabled. If not set, uses the text passed in as values in props as a fallback

--- a/src/SegmentedControlTab.js
+++ b/src/SegmentedControlTab.js
@@ -25,6 +25,7 @@ type Props = {
   onTabPress: Function,
   textNumberOfLines: number,
   allowFontScaling: boolean,
+  maxFontSizeMultiplier: number | null,
   accessible: boolean,
   activeTabOpacity: number,
   enabled: boolean,
@@ -116,6 +117,7 @@ export default class SegmentedControlTab extends PureComponent<Props> {
     borderRadius: 5,
     textNumberOfLines: 1,
     allowFontScaling: true,
+    maxFontSizeMultiplier: null,
     activeTabOpacity: 1,
     enabled: true,
   };
@@ -144,6 +146,7 @@ export default class SegmentedControlTab extends PureComponent<Props> {
       onTabPress,
       textNumberOfLines,
       allowFontScaling,
+      maxFontSizeMultiplier,
       accessible,
       accessibilityLabels,
       testIDs,
@@ -216,6 +219,7 @@ export default class SegmentedControlTab extends PureComponent<Props> {
               tabBadgeStyle={tabBadgeStyle}
               activeTabBadgeStyle={activeTabBadgeStyle}
               allowFontScaling={allowFontScaling}
+              maxFontSizeMultiplier={maxFontSizeMultiplier}
               activeTabOpacity={activeTabOpacity}
               accessible={accessible}
               accessibilityLabel={accessibilityText || item}

--- a/src/TabOption.js
+++ b/src/TabOption.js
@@ -32,6 +32,7 @@ type Props = {
   onTabPress: Function,
   textNumberOfLines?: number,
   allowFontScaling?: boolean,
+  maxFontSizeMultiplier?: number | null,
   accessible?: boolean,
   activeTabOpacity?: number,
   accessibilityLabel?: string,
@@ -123,6 +124,7 @@ export default class TabOption extends PureComponent<Props> {
       onTabPress,
       textNumberOfLines,
       allowFontScaling,
+      maxFontSizeMultiplier,
       accessible,
       activeTabOpacity,
       accessibilityLabel,
@@ -158,6 +160,7 @@ export default class TabOption extends PureComponent<Props> {
             ]}
             numberOfLines={textNumberOfLines}
             allowFontScaling={allowFontScaling}
+            maxFontSizeMultiplier={maxFontSizeMultiplier}
             ellipsizeMode="tail"
           >
             {text}
@@ -184,6 +187,7 @@ export default class TabOption extends PureComponent<Props> {
                     : {},
                 ]}
                 allowFontScaling={allowFontScaling}
+                maxFontSizeMultiplier={maxFontSizeMultiplier}
               >
                 {badge}
               </Text>

--- a/src/__tests__/__snapshots__/SegmentedControlTab.js.snap
+++ b/src/__tests__/__snapshots__/SegmentedControlTab.js.snap
@@ -42,6 +42,7 @@ exports[`<SegmentedControlTab /> should render default SegmentedControlTab 1`] =
     index={0}
     isTabActive={true}
     lastTabStyle={Object {}}
+    maxFontSizeMultiplier={null}
     onTabPress={[Function]}
     tabBadgeContainerStyle={Object {}}
     tabBadgeStyle={Object {}}
@@ -71,6 +72,7 @@ exports[`<SegmentedControlTab /> should render default SegmentedControlTab 1`] =
     index={1}
     isTabActive={false}
     lastTabStyle={Object {}}
+    maxFontSizeMultiplier={null}
     onTabPress={[Function]}
     tabBadgeContainerStyle={Object {}}
     tabBadgeStyle={Object {}}
@@ -116,6 +118,7 @@ exports[`<SegmentedControlTab /> should render default SegmentedControlTab 1`] =
         Object {},
       ]
     }
+    maxFontSizeMultiplier={null}
     onTabPress={[Function]}
     tabBadgeContainerStyle={Object {}}
     tabBadgeStyle={Object {}}


### PR DESCRIPTION
#43 added support for `allowFontScaling`, but React Native also supports a `maxFontSizeMultiplier`. This pull requests implements that in the same way!